### PR TITLE
Improved game 011

### DIFF
--- a/examples/011_MatchingMoreColors/011_MatchingMoreColors.cpp
+++ b/examples/011_MatchingMoreColors/011_MatchingMoreColors.cpp
@@ -289,6 +289,8 @@ bool playMatchingMoreColors(){
 
     updateTouchpadLights();
 
+    hub.SetButtonAudioEnabled(true);
+
     // Record start timestamp for performance logging
     timestamp_before = millis();
 
@@ -395,7 +397,9 @@ bool playMatchingMoreColors(){
             hub.PlayAudio(hub.AUDIO_NEGATIVE, 80);
             // give the Hub a moment to finish playing the reward sound
             yield_sleep_ms(SOUND_FOODTREAT_DELAY, false);
-
+            // turn off touchpads sound and light during time-out
+            hub.SetLights(hub.LIGHT_BTNS, 0, 0, 0);
+            hub.SetButtonAudioEnabled(false);
             yield_sleep_ms(WRONG_INTERACTION_DELAY, false);
         }
     }


### PR DESCRIPTION
This PR improves game 011.

When the player misses, the miss sound would play, but the touchpads would stay lit up and the buttons would keep making sounds. Which confuses the player, since it seems the game is still going without the touchpads changing color.

This PR mutes touchpad sounds and turns off the touchpad lights after the miss sound.