### PR TITLE
added challengeComplete metric to report, cleaned up some vars

### DIFF
--- a/examples/000_EatingTheFood/000_EatingTheFood.cpp
+++ b/examples/000_EatingTheFood/000_EatingTheFood.cpp
@@ -144,7 +144,7 @@ bool playEatingTheFood() {
   Log.info("Sending report");
   
   String extra = "{";
-  if (challengeComplete) {extra += ",\"challengeComplete\":1";};
+  if (challengeComplete) {extra += ",\"challengeComplete\":1";}
   extra += "}";
 
   hub.Report(

--- a/examples/000_EatingTheFood/000_EatingTheFood.cpp
+++ b/examples/000_EatingTheFood/000_EatingTheFood.cpp
@@ -54,6 +54,7 @@ const unsigned long SOUND_FOODTREAT_DELAY = 1200;  // (ms) delay for reward
 int performance[HISTORY_LENGTH] = {0};  // store the progress in this challenge
 int perfPos = 0;                        // position in the performance array
 bool foodtreatWasEaten = false;  // store if foodtreat was eaten in last interaction
+bool challengeComplete = false; // do not re-initialize
 
 // Use primary serial over USB interface for logging output (9600)
 // Choose logging level here (ERROR, WARN, INFO)
@@ -77,12 +78,14 @@ SYSTEM_THREAD(ENABLED);
 bool playEatingTheFood() {
   yield_begin();
 
-  static unsigned long gameStartTime, timestamp_before, activityDuration = 0;
+  static unsigned long gameStartTime, timestampBefore, activityDuration = 0;
   static unsigned char foodtreatState = 99;
 
   // Static variables and constants are only initialized once, and need to be
   // re-initialized on subsequent calls
-  gameStartTime, timestamp_before, activityDuration = 0;
+  gameStartTime = 0;
+  timestampBefore = 0;
+  activityDuration = 0;
   foodtreatState = 99;
 
   Log.info("-------------------------------------------");
@@ -109,7 +112,7 @@ bool playEatingTheFood() {
            FOODTREAT_DURATIONS[currentLevel - 1]);
 
   // Record start timestamp for performance logging
-  timestamp_before = millis();
+  timestampBefore = millis();
 
   // play "reward" sound
   hub.PlayAudio(hub.AUDIO_POSITIVE, 20);
@@ -126,7 +129,7 @@ bool playEatingTheFood() {
 
   // record time period for performance logging
   // (activity duration will always be interaction time + tray movement)
-  activityDuration = millis() - timestamp_before;
+  activityDuration = millis() - timestampBefore;
 
   // check if foodtreat was eaten
   if (foodtreatState == hub.PACT_RESPONSE_FOODTREAT_TAKEN) {
@@ -139,6 +142,11 @@ bool playEatingTheFood() {
 
   // send report
   Log.info("Sending report");
+  
+  String extra = "{";
+  if (challengeComplete) {extra += ",\"challengeComplete\":1";};
+  extra += "}";
+
   hub.Report(
       Time.format(gameStartTime, TIME_FORMAT_ISO8601_FULL),  // play_start_time
       playerName,                                            // player
@@ -147,7 +155,8 @@ bool playEatingTheFood() {
       activityDuration,  // duration -> linked to level and includes tray
                          // movement
       1,                 // foodtreat_presented
-      foodtreatWasEaten  // foodtreat_eaten
+      foodtreatWasEaten,  // foodtreat_eaten
+      extra              // extra field
   );
 
   // decide if level is going up or down
@@ -213,7 +222,7 @@ void loop() {
     perf_total += performance[i];
     if (perf_total >= ENOUGH_SUCCESSES) {
       Log.info("Challenge completed!");
-      // TODO go to next challenge code
+      challengeComplete = true;
       // reset performance
       perf_total = 0;
       for (unsigned char i = 0; i < HISTORY_LENGTH; ++i) performance[i] = 0;

--- a/examples/001_ExploringTheTouchpads/001_ExploringTheTouchpads.cpp
+++ b/examples/001_ExploringTheTouchpads/001_ExploringTheTouchpads.cpp
@@ -240,7 +240,7 @@ bool playExploringTheTouchpads() {
     Log.info("Sending report");
 
     String extra = "{";
-    if (challengeComplete) {extra += ",\"challengeComplete\":1";}; //TODO this comes one game too late
+    if (challengeComplete) {extra += ",\"challengeComplete\":1";} //TODO this comes one game too late
     extra += "}";
 
     hub.Report(

--- a/examples/001_ExploringTheTouchpads/001_ExploringTheTouchpads.cpp
+++ b/examples/001_ExploringTheTouchpads/001_ExploringTheTouchpads.cpp
@@ -139,8 +139,9 @@ bool playExploringTheTouchpads() {
   yield_begin();
 
   static bool foodtreatWasEaten = false; // store if foodtreat was eaten in last interaction
-  static unsigned long timestamp_before, reaction_time, gameStartTime = 0;
+  static unsigned long timestampBefore, reactionTime, gameStartTime = 0;
   static bool timeout = false;          // holds timeout state
+  static bool challengeComplete = false; // do not re-initialize
   static int foodtreatState = 99;       // holds return value of foodmachine
   static int FLASHING = 0;              // 0: no FLASHING
   static int FLASHING_DUTY_CYCLE = 99;  // ignored since no FLASHING
@@ -150,7 +151,9 @@ bool playExploringTheTouchpads() {
   // Static variables and constants are only initialized once, and need to be
   // re-initialized on subsequent calls
   foodtreatWasEaten = false;       // store if foodtreat was eaten in last interaction
-  timestamp_before, reaction_time, gameStartTime = 0;
+  timestampBefore = 0;
+  reactionTime = 0;
+  gameStartTime = 0;
   timeout = false;         // holds timeout state
   foodtreatState = 99;     // holds return value of foodmachine
   pressed = 0;    // bit field that holds which touchpad was
@@ -178,7 +181,7 @@ bool playExploringTheTouchpads() {
   hub.SetDIResetLock(true);
 
   // Record start timestamp for performance logging
-  timestamp_before = millis();
+  timestampBefore = millis();
 
   // Turn on touchpad lights
   hub.SetRandomButtonLights(3, YELLOW, BLUE, FLASHING, FLASHING_DUTY_CYCLE);
@@ -190,10 +193,10 @@ bool playExploringTheTouchpads() {
   } while ((pressed != hub.BUTTON_LEFT && pressed != hub.BUTTON_MIDDLE &&
             pressed != hub.BUTTON_RIGHT) &&
            millis() <
-                (timestamp_before + TIMEOUT_DURATIONS[currentLevel - 1]));
+                (timestampBefore + TIMEOUT_DURATIONS[currentLevel - 1]));
 
   // Record time period for performance logging
-  reaction_time = millis() - timestamp_before;
+  reactionTime = millis() - timestampBefore;
 
   // Turn off lights
   hub.SetLights(hub.LIGHT_BTNS, 0, 0, 0);
@@ -232,17 +235,24 @@ bool playExploringTheTouchpads() {
   }
 
   if (!timeout) {
+
     // Send report
     Log.info("Sending report");
+
+    String extra = "{";
+    if (challengeComplete) {extra += ",\"challengeComplete\":1";}; //TODO this comes one game too late
+    extra += "}";
+
     hub.Report(
         Time.format(gameStartTime,
                     TIME_FORMAT_ISO8601_FULL), // play_start_time
         playerName,                           // player
         currentLevel,                         // level
         String(foodtreatWasEaten),           // result
-        reaction_time, // duration -> linked to level and includes tray movement
+        reactionTime, // duration -> linked to level and includes tray movement
         1,             // foodtreat_presented
-        foodtreatWasEaten // foodtreatWasEaten
+        foodtreatWasEaten, // foodtreatWasEaten
+        extra             // extra field
     );
   }
 
@@ -251,7 +261,7 @@ bool playExploringTheTouchpads() {
     addResultToPerformanceHistory(foodtreatWasEaten);
     if (countSuccesses() >= ENOUGH_SUCCESSES) {
       Log.info("At MAX level! %u", currentLevel);
-      // TODO At MAX level CHALLENGE DONE
+      challengeComplete = true;
       resetPerformanceHistory();
     }
   } else {

--- a/examples/002_EngagingConsistently/002_EngagingConsistently.cpp
+++ b/examples/002_EngagingConsistently/002_EngagingConsistently.cpp
@@ -276,7 +276,7 @@ bool playEngagingConsistently() {
   Log.info("Sending report");
   String extra = String::format(
       "{\"pos_tries\":%u,\"neg_tries\":%u", countSuccesses(), countMisses());
-  if (challengeComplete) {extra += ",\"challengeComplete\":1";};
+  if (challengeComplete) {extra += ",\"challengeComplete\":1";}
   extra += "}";
 
   hub.Report(

--- a/examples/003_AvoidingUnlitTouchpads/003_AvoidingUnlitTouchpads.cpp
+++ b/examples/003_AvoidingUnlitTouchpads/003_AvoidingUnlitTouchpads.cpp
@@ -320,7 +320,7 @@ bool playAvoidingUnlitTouchpads() {
     extra += "\",\"pressed\":\"";
     extra += convertBitfieldToLetter(pressed);
     extra += String::format("\",\"retryGame\":\"%c\"", retryTarget ? '1' : '0');
-    if (challengeComplete) {extra += ",\"challengeComplete\":1";};
+    if (challengeComplete) {extra += ",\"challengeComplete\":1";}
     extra += "}";
 
     hub.Report(Time.format(gameStartTime,

--- a/examples/004_LearningTheLights/004_LearningTheLights.cpp
+++ b/examples/004_LearningTheLights/004_LearningTheLights.cpp
@@ -313,7 +313,7 @@ bool playLearningTheLights() {
     extra += "\",\"pressed\":\"";
     extra += convertBitfieldToLetter(pressed);
     extra += String::format("\",\"retryGame\":\"%c\"", retryTarget ? '1' : '0');
-    if (challengeComplete) {extra += ",\"challengeComplete\":1";};
+    if (challengeComplete) {extra += ",\"challengeComplete\":1";}
     extra += "}";
     
     hub.Report(Time.format(gameStartTime,

--- a/examples/005_MasteringTheLights/005_MasteringTheLights.cpp
+++ b/examples/005_MasteringTheLights/005_MasteringTheLights.cpp
@@ -317,7 +317,7 @@ bool playMasteringTheLights() {
     extra += "\",\"pressed\":\"";
     extra += convertBitfieldToLetter(pressed);
     extra += String::format("\",\"retryGame\":\"%c\"", retryTarget ? '1' : '0');
-    if (challengeComplete) {extra += ",\"challengeComplete\":1";};
+    if (challengeComplete) {extra += ",\"challengeComplete\":1";}
     extra += "}";
 
     hub.Report(Time.format(gameStartTime,

--- a/examples/005_MasteringTheLights/005_MasteringTheLights.cpp
+++ b/examples/005_MasteringTheLights/005_MasteringTheLights.cpp
@@ -151,7 +151,7 @@ String convertBitfieldToLetter(unsigned char pad){
 bool playMasteringTheLights() {
   yield_begin();
 
-  static unsigned long timestamp_before, activityDuration = 0;
+  static unsigned long timestampBefore, activityDuration = 0;
   static unsigned long gameStartTime = 0;
   static unsigned char target = 0;
   static unsigned char retryTarget = 0; // should not be re-initialized
@@ -159,21 +159,23 @@ bool playMasteringTheLights() {
   static bool accurate = false;
   static bool timeout = false;
   static unsigned char pressed = 0;
-  static unsigned long time_start_wait = 0;
+  static unsigned long timestampTouchpad = 0;
   static int yellow = 60;
   static int blue = 60;
   static bool foodtreatWasEaten = false; // store if foodtreat was eaten in last interaction
+  static bool challengeComplete = false; // do not re-initialize
 
   // Static variable and constants are only initialized once, and need to be re-initialized
   // on subsequent calls
-  timestamp_before, activityDuration = 0;
+  timestampBefore = 0;
+  activityDuration = 0;
   gameStartTime = 0;
   target = 0;
   foodtreatState = 99;
   accurate = false;
   timeout = false;
   pressed = 0;
-  time_start_wait = 0;
+  timestampTouchpad = 0;
   yellow = 60;
   blue = 60;
   foodtreatWasEaten = false; // store if foodtreat was eaten in last interaction
@@ -200,7 +202,7 @@ bool playMasteringTheLights() {
   hub.SetDIResetLock(true);
 
   // Record start timestamp for performance logging
-  timestamp_before = millis();
+  timestampBefore = millis();
 
   yellow = random(20, 90); // pick a yellow for interaction
   blue = random(20, 90);   // pick a blue for interaction
@@ -216,7 +218,7 @@ bool playMasteringTheLights() {
   }
 
   // progress to next state
-  time_start_wait = millis();
+  timestampTouchpad = millis();
 
   do {
     // detect any buttons currently pressed
@@ -225,10 +227,10 @@ bool playMasteringTheLights() {
   } while (
       (pressed != hub.BUTTON_LEFT // we want it to just be a single touchpad
        && pressed != hub.BUTTON_MIDDLE && pressed != hub.BUTTON_RIGHT) &&
-      millis() < time_start_wait + TIMEOUT_MS);
+      millis() < timestampTouchpad + TIMEOUT_MS);
 
   // record time period for performance logging
-  activityDuration = millis() - timestamp_before;
+  activityDuration = millis() - timestampBefore;
 
   hub.SetLights(hub.LIGHT_BTNS, 0, 0, 0); // turn off lights
 
@@ -292,7 +294,7 @@ bool playMasteringTheLights() {
       addResultToPerformanceHistory(accurate);
       if (countSuccesses() >= ENOUGH_SUCCESSES) {
         Log.info("At MAX level! %u", currentLevel);
-        // TODO At MAX level CHALLENGE DONE
+        challengeComplete = true;
         resetPerformanceHistory();
       }
     } else {
@@ -314,7 +316,9 @@ bool playMasteringTheLights() {
     extra += convertBitfieldToLetter(target);
     extra += "\",\"pressed\":\"";
     extra += convertBitfieldToLetter(pressed);
-    extra += String::format("\",\"retryGame\":\"%c\"}", retryTarget ? '1' : '0');
+    extra += String::format("\",\"retryGame\":\"%c\"", retryTarget ? '1' : '0');
+    if (challengeComplete) {extra += ",\"challengeComplete\":1";};
+    extra += "}";
 
     hub.Report(Time.format(gameStartTime,
                            TIME_FORMAT_ISO8601_FULL), // play_start_time

--- a/examples/006_RespondingQuickly/006_RespondingQuickly.cpp
+++ b/examples/006_RespondingQuickly/006_RespondingQuickly.cpp
@@ -386,7 +386,7 @@ bool playRespondingQuickly() {
     // multiple touches possible, only report a single wrong one if a miss
     extra += convertBitfieldToSingleLetter(touchpads[1],pressed[1]);
     extra += String::format("\",\"retryGame\":\"%c\"", retryTarget ? '1' : '0');
-    if (challengeComplete) {extra += ",\"challengeComplete\":1";};
+    if (challengeComplete) {extra += ",\"challengeComplete\":1";}
     extra += "}";
 
     hub.Report(Time.format(gameStartTime,

--- a/examples/007_LearningBrightness/007_LearningBrightness.cpp
+++ b/examples/007_LearningBrightness/007_LearningBrightness.cpp
@@ -209,8 +209,8 @@ bool playLearningBrightness(){
 
     static unsigned char distractor_intensity_probes[8] = { // should not be re-initialized
         17, 21, 26, 33, 41, 51, 64, 80};
-    static unsigned long gameStartTime, timestamp_before, activityDuration = 0;
-    static unsigned long time_start_wait = 0;
+    static unsigned long gameStartTime, timestampBefore, activityDuration = 0;
+    static unsigned long timestampTouchpad = 0;
     static unsigned char pressed[2] = {0,0};
     static unsigned char foodtreatState = 99;
     static unsigned char touchpads[3]={hub.BUTTON_LEFT,  // should not be re-initialized
@@ -222,13 +222,14 @@ bool playLearningBrightness(){
     static bool accurate = false;
     static bool timeout = false;
     static bool foodtreatWasEaten = false; // store if foodtreat was eaten in last interaction
+    static bool challengeComplete = false; // do not re-initialize
 
   // Static variables and constants are only initialized once, and need to be re-initialized
   // on subsequent calls
     gameStartTime = 0;
-    timestamp_before = 0;
+    timestampBefore = 0;
     activityDuration = 0;
-    time_start_wait = 0;
+    timestampTouchpad = 0;
     pressed[0] = 0;
     pressed[1] = 0;
     foodtreatState = 99;
@@ -257,7 +258,7 @@ bool playLearningBrightness(){
     hub.SetDIResetLock(true);
 
     // Record start timestamp for performance logging
-    timestamp_before = millis();
+    timestampBefore = millis();
 
     if (retryTarget){
         Log.info("We're doing a retry interaction");
@@ -285,7 +286,7 @@ bool playLearningBrightness(){
     hub.SetLights(touchpads[0],TARGET_INTENSITY,TARGET_INTENSITY,SLEW);
 
     // progress to next state
-    time_start_wait = millis();
+    timestampTouchpad = millis();
     do
     {
         // detect any touchpads currently pressed
@@ -293,7 +294,7 @@ bool playLearningBrightness(){
         yield(false); // use yields statements any time the hub is pausing or waiting
     } // Ignore non-target touches
     while (!(pressed[0] == touchpads[0]) //0 if only pressed touchpad match
-            && millis()  < time_start_wait + TIMEOUT_MS); //0 if timed out
+            && millis()  < timestampTouchpad + TIMEOUT_MS); //0 if timed out
 
     hub.SetLights(hub.LIGHT_BTNS, 0, 0, 0); // turn off all touchpad lights
 
@@ -311,7 +312,7 @@ bool playLearningBrightness(){
 
         yield_sleep_ms(VIEW_WINDOW, false); // make sure the player has seen the touchpad
 
-        time_start_wait = millis();
+        timestampTouchpad = millis();
 
         do
         {
@@ -320,12 +321,12 @@ bool playLearningBrightness(){
             yield(false); // use yields statements any time the hub is pausing or waiting
         }
         while (!(pressed[1] != 0) //0 if any touchpad is touched
-                && millis()  < time_start_wait + MAX_REACTION_TIME); //0 if timed out
+                && millis()  < timestampTouchpad + MAX_REACTION_TIME); //0 if timed out
 
         hub.SetLights(hub.LIGHT_BTNS, 0, 0, 0); // turn off all touchpad lights
 
         // record time period for performance logging
-        activityDuration = millis() - timestamp_before;
+        activityDuration = millis() - timestampBefore;
 
         //check touchpads and accuracy for second interaction
         if (pressed[1] == 0){
@@ -396,7 +397,7 @@ discarding performance.");
     if (currentLevel == MAX_LEVEL){
         if (countSuccesses() >= ENOUGH_SUCCESSES){
             Log.info("At MAX level! %u", currentLevel);
-            //TODO At MAX level CHALLENGE DONE
+            challengeComplete = true;
             resetPerformanceHistory();
         }
     } else {
@@ -423,8 +424,10 @@ discarding performance.");
         // multiple touches possible, only report the wrong one if a miss
         extra += convertBitfieldToSingleLetter(touchpads[1],pressed[1]);
         extra += String::format(
-            "\",\"distractor_intensity\":%d,\"retryGame\":\"%c\"}",
+            "\",\"distractor_intensity\":%d,\"retryGame\":\"%c\"",
             distractor_intensity, retryTarget ? '1' : '0');
+        if (challengeComplete) {extra += ",\"challengeComplete\":1";};
+        extra += "}";
 
         hub.Report(Time.format(gameStartTime,
                                TIME_FORMAT_ISO8601_FULL),  // play_start_time

--- a/examples/007_LearningBrightness/007_LearningBrightness.cpp
+++ b/examples/007_LearningBrightness/007_LearningBrightness.cpp
@@ -426,7 +426,7 @@ discarding performance.");
         extra += String::format(
             "\",\"distractor_intensity\":%d,\"retryGame\":\"%c\"",
             distractor_intensity, retryTarget ? '1' : '0');
-        if (challengeComplete) {extra += ",\"challengeComplete\":1";};
+        if (challengeComplete) {extra += ",\"challengeComplete\":1";}
         extra += "}";
 
         hub.Report(Time.format(gameStartTime,

--- a/examples/008_LearningDoubleSequences/008_LearningDoubleSequences.cpp
+++ b/examples/008_LearningDoubleSequences/008_LearningDoubleSequences.cpp
@@ -399,7 +399,7 @@ bool playLearningDoubleSequences(){
             extra += convertBitfieldToSingleLetter(touchpad_sequence[i],pressed[i+1]);
         }
         extra += "\"";
-        if (challengeComplete) {extra += ",\"challengeComplete\":1";};
+        if (challengeComplete) {extra += ",\"challengeComplete\":1";}
         extra += "}";
 
         // Log.info(extra);

--- a/examples/008_LearningDoubleSequences/008_LearningDoubleSequences.cpp
+++ b/examples/008_LearningDoubleSequences/008_LearningDoubleSequences.cpp
@@ -191,7 +191,7 @@ String convertBitfieldToSingleLetter(unsigned char targetPad, unsigned char pad)
 bool playLearningDoubleSequences(){
     yield_begin();
 
-    static unsigned long gameStartTime, time_start_wait, timestamp_before, activityDuration = 0;
+    static unsigned long gameStartTime, timestampTouchpad, timestampBefore, activityDuration = 0;
     static unsigned char foodtreatState = 99;
     static unsigned char touchpads[3]={hub.BUTTON_LEFT,
                                      hub.BUTTON_MIDDLE,
@@ -202,12 +202,13 @@ bool playLearningDoubleSequences(){
     static bool accurate = false;
     static bool timeout = false;
     static bool foodtreatWasEaten = false; // store if foodtreat was eaten in last interaction
+    static bool challengeComplete = false; // do not re-initialize
 
   // Static variables and constants are only initialized once, and need to be re-initialized
   // on subsequent calls
     gameStartTime=0;
-    time_start_wait=0;
-    timestamp_before =0;
+    timestampTouchpad=0;
+    timestampBefore =0;
     activityDuration = 0;
     foodtreatState = 99;
     sequence_pos = 0;
@@ -250,7 +251,7 @@ bool playLearningDoubleSequences(){
     hub.SetLights(hub.LIGHT_BTNS,TARGET_INTENSITY,TARGET_INTENSITY,SLEW);
 
     // progress to next state
-    time_start_wait = millis();
+    timestampTouchpad = millis();
 
     do
     {
@@ -259,7 +260,7 @@ bool playLearningDoubleSequences(){
         yield(false); // use yields statements any time the hub is pausing or waiting
     }
     while (!(pressed[0] != 0) //0 if any touchpad is touched
-            && millis()  < time_start_wait + TIMEOUT_MS); //0 if timed out
+            && millis()  < timestampTouchpad + TIMEOUT_MS); //0 if timed out
 
     hub.SetLights(hub.LIGHT_BTNS, 0, 0, 0); // turn off all touchpad lights
 
@@ -280,7 +281,7 @@ bool playLearningDoubleSequences(){
     }
 
     // Record start timestamp for performance logging
-    timestamp_before = millis();
+    timestampBefore = millis();
 
     // Start main interactions loop
     while (sequence_pos < SEQUENCE_LENGTH) {
@@ -300,7 +301,7 @@ bool playLearningDoubleSequences(){
         hub.SetLights(touchpad_sequence[sequence_pos],TARGET_INTENSITY,TARGET_INTENSITY,SLEW);
 
         // progress to next state
-        time_start_wait = millis();
+        timestampTouchpad = millis();
 
         do
         {
@@ -309,7 +310,7 @@ bool playLearningDoubleSequences(){
             yield(false); // use yields statements any time the hub is pausing or waiting
         }
         while (!(pressed[sequence_pos+1] != 0) //0 if any touchpad is touched
-                && millis()  < time_start_wait + TIMEOUT_MS); //0 if timed out
+                && millis()  < timestampTouchpad + TIMEOUT_MS); //0 if timed out
 
 
         if (pressed[sequence_pos+1] == 0) {
@@ -333,7 +334,7 @@ bool playLearningDoubleSequences(){
     }
 
     // record time period for performance logging
-    activityDuration = millis() - timestamp_before;
+    activityDuration = millis() - timestampBefore;
 
     hub.SetLights(hub.LIGHT_BTNS, 0, 0, 0); // turn off all touchpad lights
 
@@ -379,7 +380,7 @@ bool playLearningDoubleSequences(){
     if (currentLevel == MAX_LEVEL){
         if (countSuccesses() >= ENOUGH_SUCCESSES){
             Log.info("At MAX level! %u", currentLevel);
-            //TODO At MAX level CHALLENGE DONE
+            challengeComplete = true;
             resetPerformanceHistory();
         }
     }
@@ -389,20 +390,17 @@ bool playLearningDoubleSequences(){
         Log.info("Sending report");
 
         String extra ="{";
-
         extra += "\"targetSeq\":\"";
-
         for (int i = 0; i < SEQUENCE_LENGTH; ++i){
             extra += convertBitfieldToLetter(touchpad_sequence[i]);
         }
-
         extra += "\",\"pressedSeq\":\"";
-
         for (int i = 0; i < SEQUENCE_LENGTH; ++i){
             extra += convertBitfieldToSingleLetter(touchpad_sequence[i],pressed[i+1]);
         }
-
-        extra += "\"}";
+        extra += "\"";
+        if (challengeComplete) {extra += ",\"challengeComplete\":1";};
+        extra += "}";
 
         // Log.info(extra);
 

--- a/examples/009_LearningLongerSequences/009_LearningLongerSequences.cpp
+++ b/examples/009_LearningLongerSequences/009_LearningLongerSequences.cpp
@@ -438,7 +438,7 @@ bool playLearningLongerSequences(){
             extra += convertBitfieldToSingleLetter(touchpad_sequence[i],pressed[i+1]);
         }
         extra += String::format("\",\"lives\":%d",lives);
-        if (challengeComplete) {extra += ",\"challengeComplete\":1";};
+        if (challengeComplete) {extra += ",\"challengeComplete\":1";}
         extra += "}";
 
         // Log.info(extra);

--- a/examples/009_LearningLongerSequences/009_LearningLongerSequences.cpp
+++ b/examples/009_LearningLongerSequences/009_LearningLongerSequences.cpp
@@ -196,7 +196,7 @@ String convertBitfieldToSingleLetter(unsigned char targetPad, unsigned char pad)
 bool playLearningLongerSequences(){
     yield_begin();
 
-    static unsigned long timestamp_before, time_start_wait, gameStartTime, activityDuration = 0;
+    static unsigned long timestampBefore, timestampTouchpad, gameStartTime, activityDuration = 0;
     static unsigned char foodtreatState = 99;
     static int lives = LIVES_START_STATE;
     static unsigned char touchpads[3]={hub.BUTTON_LEFT,
@@ -208,11 +208,12 @@ bool playLearningLongerSequences(){
     static bool accurate = false;
     static bool timeout = false;
     static bool foodtreatWasEaten = false; // store if foodtreat was eaten in last interaction
+    static bool challengeComplete = false; // do not re-initialize
 
     // Static variable and constants are only initialized once, and need to be re-initialized
     // on subsequent calls
-    timestamp_before = 0;
-    time_start_wait = 0;
+    timestampBefore = 0;
+    timestampTouchpad = 0;
     gameStartTime = 0;
     activityDuration = 0;
     foodtreatState = 99;
@@ -257,7 +258,7 @@ bool playLearningLongerSequences(){
     hub.SetLights(hub.LIGHT_BTNS,TARGET_INTENSITY,TARGET_INTENSITY,SLEW);
 
     // progress to next state
-    time_start_wait = millis();
+    timestampTouchpad = millis();
 
     do
     {
@@ -268,7 +269,7 @@ bool playLearningLongerSequences(){
     }
     while (!(pressed[0] != 0) //0 if any touchpad is touched
             //0 if timed out
-            && millis()  < time_start_wait + TIMEOUT_STIMULUS_MS);
+            && millis()  < timestampTouchpad + TIMEOUT_STIMULUS_MS);
 
     hub.SetLights(hub.LIGHT_BTNS, 0, 0, 0); // turn off all touchpad lights
 
@@ -289,7 +290,7 @@ bool playLearningLongerSequences(){
     }
 
     // Record start timestamp for performance logging
-    timestamp_before = millis();
+    timestampBefore = millis();
 
     // Start main interactions loop
     while (sequence_pos < sequenceLength) {
@@ -309,7 +310,7 @@ bool playLearningLongerSequences(){
         hub.SetLights(touchpad_sequence[sequence_pos],TARGET_INTENSITY,TARGET_INTENSITY,SLEW);
 
         // progress to next state
-        time_start_wait = millis();
+        timestampTouchpad = millis();
         do
         {
             // detect any buttons currently pressed
@@ -318,7 +319,7 @@ bool playLearningLongerSequences(){
             yield(false); // use yields statements any time the hub is pausing or waiting
         }
         while (!(pressed[sequence_pos+1] != 0) //0 if any touchpad is touched
-                && millis()  < time_start_wait + TIMEOUT_INTERACTIONS_MS); //0 if timed out
+                && millis()  < timestampTouchpad + TIMEOUT_INTERACTIONS_MS); //0 if timed out
 
         if (pressed[sequence_pos+1] == 0) {
             Log.info("No touchpad pressed, timeout");
@@ -356,7 +357,7 @@ bool playLearningLongerSequences(){
     }
 
     // record time period for performance logging
-    activityDuration = millis() - timestamp_before;
+    activityDuration = millis() - timestampBefore;
 
     hub.SetLights(hub.LIGHT_BTNS, 0, 0, 0); // turn off all touchpad lights
 
@@ -396,7 +397,7 @@ bool playLearningLongerSequences(){
     {
         resetPerformanceHistory();
         Log.info("At MAX length! %u", sequenceLength);
-        //TODO At MAX length CHALLENGE DONE
+        challengeComplete = true;
     }
 
     // keep track of performance
@@ -427,20 +428,18 @@ bool playLearningLongerSequences(){
         Log.info("Sending report");
 
         String extra ="{";
-
         extra += "\"targetSeq\":\"";
-
         for (int i = 0; i < sequenceLength; ++i){
             extra += convertBitfieldToLetter(touchpad_sequence[i]);
         }
-
         extra += "\",\"pressedSeq\":\"";
         // TODO also report wrong touches that deducted lives?
         for (int i = 0; i < sequenceLength; ++i){
             extra += convertBitfieldToSingleLetter(touchpad_sequence[i],pressed[i+1]);
         }
-
-        extra += String::format("\",\"lives\":%d}",lives);
+        extra += String::format("\",\"lives\":%d",lives);
+        if (challengeComplete) {extra += ",\"challengeComplete\":1";};
+        extra += "}";
 
         // Log.info(extra);
 

--- a/examples/010_MatchingTwoColors/010_MatchingTwoColors.cpp
+++ b/examples/010_MatchingTwoColors/010_MatchingTwoColors.cpp
@@ -421,7 +421,7 @@ bool playMatchingTwoColors(){
             REPORT_COLORS[touchpadsColorStart[2]], pressedSeq.c_str(),
             pads_pressed,
             retryGame ? '1' : '0');  // TODO this is the new value
-        if (challengeComplete) {extra += ",\"challengeComplete\":1";};
+        if (challengeComplete) {extra += ",\"challengeComplete\":1";}
         extra += "}";
 
         // Log.info(extra);

--- a/examples/011_MatchingMoreColors/011_MatchingMoreColors.cpp
+++ b/examples/011_MatchingMoreColors/011_MatchingMoreColors.cpp
@@ -197,7 +197,7 @@ String convertBitfieldToLetter(unsigned char pad){
 bool playMatchingMoreColors(){
     yield_begin();
 
-    static unsigned long timestamp_before, gameStartTime, time_start_wait, activityDuration = 0;
+    static unsigned long timestampBefore, gameStartTime, timestampTouchpad, activityDuration = 0;
     static unsigned char foodtreatState = 99;
     static unsigned char touchpadsColorStart[3] = {};
     static unsigned char pressed = 0;
@@ -209,13 +209,14 @@ bool playMatchingMoreColors(){
     static bool accurate = false;
     static bool timeout = false;
     static bool foodtreatWasEaten = false; // store if foodtreat was eaten in last interaction
+    static bool challengeComplete = false; // do not re-initialize
     static String pressedSeq = "";
 
     // Static variables and constants are only initialized once, and need to be re-initialized
     // on subsequent calls
-    timestamp_before = 0;
+    timestampBefore = 0;
     gameStartTime = 0;
-    time_start_wait = 0;
+    timestampTouchpad = 0;
     activityDuration = 0;
     foodtreatState = 99;
     PADS_PRESSED_MAX_override = 0;
@@ -292,11 +293,11 @@ bool playMatchingMoreColors(){
     hub.SetButtonAudioEnabled(true);
 
     // Record start timestamp for performance logging
-    timestamp_before = millis();
+    timestampBefore = millis();
 
     // main while loop
     while (match == false){
-        time_start_wait = millis();
+        timestampTouchpad = millis();
         do
         {
             yield(false); // use yields statements any time the hub is pausing or waiting
@@ -304,9 +305,9 @@ bool playMatchingMoreColors(){
             pressed = hub.AnyButtonPressed();
         }
         while (!(pressed != 0) //0 if any touchpad is touched
-                && millis()  < time_start_wait + TIMEOUT_MS); //0 if timed out
+                && millis()  < timestampTouchpad + TIMEOUT_MS); //0 if timed out
 
-        activityDuration = millis() - timestamp_before;
+        activityDuration = millis() - timestampBefore;
 
         if (pressed == hub.BUTTON_LEFT){
             Log.info("Left touchpad pressed");
@@ -415,7 +416,7 @@ bool playMatchingMoreColors(){
     if (currentLevel == MAX_LEVEL){
         if (countSuccesses() >= ENOUGH_SUCCESSES){
             Log.info("At MAX level! %u", currentLevel);
-            //TODO At MAX level CHALLENGE DONE
+            challengeComplete = true;
             retryGame = false;
             resetPerformanceHistory();
         }
@@ -445,12 +446,14 @@ bool playMatchingMoreColors(){
 
         String extra = String::format(
             "{\"start_state\":\"%c%c%c\",\"pressedSeq\":\"%s\",\"presses\":%u,"
-            "\"num_colors\":%u,\"retryGame\":%c}",
+            "\"num_colors\":%u,\"retryGame\":%c",
             REPORT_COLORS[touchpadsColorStart[0]],
             REPORT_COLORS[touchpadsColorStart[1]],
             REPORT_COLORS[touchpadsColorStart[2]], pressedSeq.c_str(),
             padsPressed, numberOfColors,
             retryGame ? '1' : '0');  // TODO this is the new value
+        if (challengeComplete) {extra += ",\"challengeComplete\":1";};
+        extra += "}";
 
         // Log.info(extra);
 

--- a/examples/011_MatchingMoreColors/011_MatchingMoreColors.cpp
+++ b/examples/011_MatchingMoreColors/011_MatchingMoreColors.cpp
@@ -452,7 +452,7 @@ bool playMatchingMoreColors(){
             REPORT_COLORS[touchpadsColorStart[2]], pressedSeq.c_str(),
             padsPressed, numberOfColors,
             retryGame ? '1' : '0');  // TODO this is the new value
-        if (challengeComplete) {extra += ",\"challengeComplete\":1";};
+        if (challengeComplete) {extra += ",\"challengeComplete\":1";}
         extra += "}";
 
         // Log.info(extra);

--- a/examples/102_OneTwoThreeButtonGame/102_OneTwoThreeButtonGame.cpp
+++ b/examples/102_OneTwoThreeButtonGame/102_OneTwoThreeButtonGame.cpp
@@ -54,7 +54,7 @@ static bool timeout;
 static char foodtreat_state;
 static unsigned char target;
 static unsigned char pressed;
-static unsigned long time_start_wait;
+static unsigned long timestampTouchpad;
 static unsigned long playstart;
 static unsigned long timer_ms;
 
@@ -88,7 +88,7 @@ bool OneTwoThreeButtonGame(int num_pads)
     timer_ms = millis();
 
     // progress to next state
-    time_start_wait = millis();
+    timestampTouchpad = millis();
 
     do
     {
@@ -99,7 +99,7 @@ bool OneTwoThreeButtonGame(int num_pads)
     while ((pressed != hub.BUTTON_LEFT // we want it to just be a single touchpad
                 && pressed != hub.BUTTON_MIDDLE
                 && pressed != hub.BUTTON_RIGHT)
-            && millis()  < time_start_wait + TIMEOUT_MS
+            && millis()  < timestampTouchpad + TIMEOUT_MS
             );
 
     timer_ms = millis() - timer_ms;

--- a/examples/104_WhackAMole/104_WhackAMole.cpp
+++ b/examples/104_WhackAMole/104_WhackAMole.cpp
@@ -55,7 +55,7 @@ String result_str;
 
 // anything that deals with millis need to be able to be big enough, hence we
 // need the data type that can express the biggest integers (unsigned long)
-static unsigned long time_start_wait;
+static unsigned long timestampTouchpad;
 static unsigned long move_wait;
 static unsigned long playstart;
 static unsigned long timer_ms;
@@ -85,16 +85,16 @@ bool WhackAMoleGame()
     // DI reset occurs if, for example, DL detects that touchpads need re-calibration, like if hub was moved to a different surface
     hub.SetDIResetLock(true);  // prevent DI board from resetting during an interaction (would cause lights to go blank etc.)
 
-    time_start_wait = millis();
-
     playstart = Time.now(); // seconds since Unix epoch (1 January 1970)
     timer_ms = millis();
 
     light_timer_ms = 0;
 
+    timestampTouchpad = millis();
+
     do
     {
-        if (millis() > time_start_wait + light_timer_ms)
+        if (millis() > timestampTouchpad + light_timer_ms)
         {
             // choose some target lights, and store which targets were randomly chosen
             target = hub.SetRandomButtonLights(1, YELLOW, BLUE, FLASHING, FLASHING_DUTY_CYCLE);
@@ -110,7 +110,7 @@ bool WhackAMoleGame()
     while ((pressed != hub.BUTTON_LEFT // we want it to just be a single touchpad
                 && pressed != hub.BUTTON_MIDDLE
                 && pressed != hub.BUTTON_RIGHT)
-            && millis()  < time_start_wait + TIMEOUT_MS
+            && millis()  < timestampTouchpad + TIMEOUT_MS
         );
 
     timer_ms = millis() - timer_ms;


### PR DESCRIPTION
## Description
This PR adds a metric to the reports in the extra section named `challengeComplete`. It only shows up if the current level is at it's maximum score and the player is cleared to go to the next challenge.
There is also some variable cleanup included in this PR.

## Motivation and Context
Before there was no easy way to see when a player had cleared a challenge. This adds a variable in the report that only shows up when the player finished the challenge

## How Has This Been Tested?
All challenges have been compiled and compile without errors. Only one of the challenges has been tested on real hardware with a real player.
All changes are similar in logic, so I expect for all challenges to work as intended

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I tried to keep my changes and amount of commits small, squashed them if possible.
- [X] I rebased this PR on top of the current master.
- [X] My change didn't introduce new compiler warnings.
- [X] My change requires a change to the documentation. -> maybe?
- [ ] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/CleverPet/HackerPet/blob/master/CONTRIBUTING.md) doc
- [X] I have signed the [CLA](https://docs.google.com/forms/d/e/1FAIpQLSeXAajtFZpQ0VtHK2APtfzrA5w8DMNagJhCfLVr6h9lCQgj1g/viewform)