### PR TITLE
New macro: yield_wait_for_with_timeout

### DIFF
--- a/src/hackerpet.h
+++ b/src/hackerpet.h
@@ -89,6 +89,22 @@ __DATE__[4], __DATE__[5], '\0' }
       }                                            \
     } while (0)
 
+/* Yield Wait For with timeout
+ *
+ * Waits for the specified number of milliseconds (timeout) or a condition while
+ * yielding whenever the condition is not true. Passes the ret parameter
+ * whenever yielding.
+ */
+#define yield_wait_for_with_timeout(condition, timeout_time_in_milliseconds, ret)\
+  do {                                                                         \
+    static unsigned long t1 = 0;                                               \
+    t1 = millis();                                                             \
+    while (!(condition) && (millis() - t1)                                     \
+           < timeout_time_in_milliseconds) {                                   \
+      yield(ret);                                                              \
+    }                                                                          \
+  } while (0)
+
 /* Yield Sleep
  *
  * Waits for the specified number of microseconds, yielding while waiting.

--- a/src/hackerpet.h
+++ b/src/hackerpet.h
@@ -92,8 +92,8 @@ __DATE__[4], __DATE__[5], '\0' }
 /* Yield Wait For with timeout
  *
  * Waits for the specified number of milliseconds (timeout) or a condition while
- * yielding whenever the condition is not true. Passes the ret parameter
- * whenever yielding.
+ * yielding whenever the condition is not true.
+ * Passes the ret parameter whenever yielding.
  */
 #define yield_wait_for_with_timeout(condition, timeout_time_in_milliseconds, ret)\
   do {                                                                         \


### PR DESCRIPTION
## Description
this PR adds a new `yield_wait_for_with_timeout` macro

## Motivation and Context
this new macro can be used to 'sleep' your code while waiting for a touchpad press

## How Has This Been Tested?
Used in the Symon game

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)